### PR TITLE
fix: case of logging bucket

### DIFF
--- a/template-management/organization-s3-bucket/cfn-organization-s3-bucket.yaml
+++ b/template-management/organization-s3-bucket/cfn-organization-s3-bucket.yaml
@@ -85,7 +85,7 @@ Resources:
     # checkov:skip=CKV_AWS_21: Versioning not enabled due to logging bucket
     Condition: cDeployAccessLogging
     Properties:
-      BucketName: !Sub pLogBucketName-${AWS::AccountId}
+      BucketName: !Sub plogbucketname-${AWS::AccountId}
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:


### PR DESCRIPTION
When enabling logging in this template it errors out because the logging bucket prefix contains mixed case and will fail S3 logging bucket creation.