### PR TITLE
feat: control tower afc

### DIFF
--- a/control-tower/controltower-afc-hub/README.md
+++ b/control-tower/controltower-afc-hub/README.md
@@ -1,0 +1,19 @@
+# Control Tower AFC Hub
+
+Before you begin to customize accounts in AWS Control Tower, you must set up a role that contains a trust relationship between AWS Control Tower management account and your hub account. When assumed, the role grants AWS Control Tower access to administer the hub account. The role must be named AWSControlTowerBlueprintAccess.
+
+AWS Control Tower assumes this role to create a Portfolio resource on your behalf in Service Catalog, then to add your blueprint as a Service Catalog Product to this Portfolio, and then to share this Portfolio, and your blueprint, with your member account during account provisioning.
+
+This template demonstrates the best practice of granting least-privilege access.
+
+## CloudFormation
+
+The solution can be deployed with the single CloudFormation template [cfn-controltower-afc-hub.yaml](./cfn-controltower-afc-hub.yaml)
+
+### CloudFormation Parameters
+
+| Parameter | Type | Default Value | Description |
+| --------- | ---- | ------------- | ----------- |
+| pManagementAccount | String | | Management account id which AWS Control Tower is deployed in. |
+| pAWSAdministratorAccessRole | String | The IAM Identity Center managed IAM Role you use to access the AWS Control Tower dashboard |
+

--- a/control-tower/controltower-afc-hub/README.md
+++ b/control-tower/controltower-afc-hub/README.md
@@ -15,5 +15,5 @@ The solution can be deployed with the single CloudFormation template [cfn-contro
 | Parameter | Type | Default Value | Description |
 | --------- | ---- | ------------- | ----------- |
 | pManagementAccount | String | | Management account id which AWS Control Tower is deployed in. |
-| pAWSAdministratorAccessRole | String | The IAM Identity Center managed IAM Role you use to access the AWS Control Tower dashboard |
+| pAWSAdministratorAccessRole | String | | The IAM Identity Center managed IAM Role you use to access the AWS Control Tower dashboard |
 

--- a/control-tower/controltower-afc-hub/cfn-controltower-afc-hub.yaml
+++ b/control-tower/controltower-afc-hub/cfn-controltower-afc-hub.yaml
@@ -1,0 +1,44 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Configure the Blueprint Access Role for Control Tower AFC
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: "Management Account Access"
+        Parameters:
+          - pManagementAccount
+          - pAWSAdministratorAccessRole
+    ParameterLabels:
+      pManagementAccountId: Management Account ID
+      pAWSAdministratorAccessRole: "AWS Admin Access Role"
+
+Parameters:
+  pManagementAccount:
+    Description: AWS Account hosting your AWS Control Tower instance
+    Type: String
+    AllowedPattern: '[0-9]+'
+  pAWSAdministratorAccessRole:
+    Description: The IAM Identity Center managed IAM Role you use to access the AWS Control Tower dashboard
+    Type: String
+
+Resources:
+  rAWSControlTowerBlueprintAccess:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: 'AWSControlTowerBlueprintAccess'
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS:
+                - !Sub 'arn:aws:iam::${pManagementAccount}:role/service-role/AWSControlTowerAdmin'
+                - !Sub 'arn:aws:iam::${pManagementAccount}:role/aws-reserved/sso.amazonaws.com/${pAWSAdministratorAccessRole}'
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+        - arn:aws:iam::aws:policy/AWSServiceCatalogAdminFullAccess

--- a/control-tower/controltower-afc-hub/cfn-controltower-afc-hub.yaml
+++ b/control-tower/controltower-afc-hub/cfn-controltower-afc-hub.yaml
@@ -8,14 +8,14 @@ Metadata:
       - Label:
           default: "Management Account Access"
         Parameters:
-          - pManagementAccount
+          - pManagementAccountId
           - pAWSAdministratorAccessRole
     ParameterLabels:
       pManagementAccountId: Management Account ID
       pAWSAdministratorAccessRole: "AWS Admin Access Role"
 
 Parameters:
-  pManagementAccount:
+  pManagementAccountId:
     Description: AWS Account hosting your AWS Control Tower instance
     Type: String
     AllowedPattern: '[0-9]+'
@@ -34,8 +34,8 @@ Resources:
           - Effect: Allow
             Principal:
               AWS:
-                - !Sub 'arn:aws:iam::${pManagementAccount}:role/service-role/AWSControlTowerAdmin'
-                - !Sub 'arn:aws:iam::${pManagementAccount}:role/aws-reserved/sso.amazonaws.com/${pAWSAdministratorAccessRole}'
+                - !Sub 'arn:aws:iam::${pManagementAccountId}:role/service-role/AWSControlTowerAdmin'
+                - !Sub 'arn:aws:iam::${pManagementAccountId}:role/aws-reserved/sso.amazonaws.com/${pAWSAdministratorAccessRole}'
             Action:
               - 'sts:AssumeRole'
       Path: /


### PR DESCRIPTION
Adds in the template to setup the trust for the management account into the Service Catalog Hub account.