### PR TITLE
fix: config logging

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -37,5 +37,6 @@ jobs:
 
     - name: Print the Cloud Formation Linter Version & run Linter.
       run: |
+        shopt -s globstar # enable globbing
         cfn-lint --version
         cfn-lint ./**/*.yaml

--- a/logging/centralized-logging-cloudtrail-s3-bucket/cfn-centralized-logging-cloudtrail-s3-bucket.yaml
+++ b/logging/centralized-logging-cloudtrail-s3-bucket/cfn-centralized-logging-cloudtrail-s3-bucket.yaml
@@ -89,15 +89,16 @@ Conditions:
 Resources:
 
   rS3AccessLoggingBucket:
-    Metadata:
-      cfn-lint:
-          ignore_checks:
-            - W3045
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Type: AWS::S3::Bucket
     # false positive due to if statement
     # checkov:skip=CKV_AWS_19:Ensure the S3 bucket has server-side-encryption enabled
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W3045
     Properties:
       BucketName: !Sub ${pS3BucketName}-access-logs-${AWS::AccountId}
       AccessControl: LogDeliveryWrite
@@ -148,15 +149,16 @@ Resources:
                 aws:SecureTransport: false
 
   rS3CloudTrailBucket:
-    Metadata:
-      cfn-lint:
-          ignore_checks:
-            - W3045
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Type: AWS::S3::Bucket
     # false positive due to if statement
     # checkov:skip=CKV_AWS_19:Ensure the S3 bucket has server-side-encryption enabled
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W3045
     Properties:
       BucketName: !Sub ${pS3BucketName}-${AWS::AccountId}
       VersioningConfiguration:

--- a/logging/centralized-logging-cloudtrail-s3-bucket/cfn-centralized-logging-cloudtrail-s3-bucket.yaml
+++ b/logging/centralized-logging-cloudtrail-s3-bucket/cfn-centralized-logging-cloudtrail-s3-bucket.yaml
@@ -89,6 +89,10 @@ Conditions:
 Resources:
 
   rS3AccessLoggingBucket:
+    Metadata:
+      cfn-lint:
+          ignore_checks:
+            - W3045
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Type: AWS::S3::Bucket
@@ -144,6 +148,10 @@ Resources:
                 aws:SecureTransport: false
 
   rS3CloudTrailBucket:
+    Metadata:
+      cfn-lint:
+          ignore_checks:
+            - W3045
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Type: AWS::S3::Bucket

--- a/logging/centralized-logging-config-s3-bucket/cfn-centralized-logging-config-s3-bucket.yaml
+++ b/logging/centralized-logging-config-s3-bucket/cfn-centralized-logging-config-s3-bucket.yaml
@@ -102,6 +102,9 @@ Resources:
         Status: Enabled
       LoggingConfiguration:
         DestinationBucketName: !Sub ${pS3BucketName}-access-logs-${AWS::AccountId}
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerPreferred
       PublicAccessBlockConfiguration:
         BlockPublicAcls: TRUE
         BlockPublicPolicy: TRUE
@@ -165,6 +168,9 @@ Resources:
         Status: Enabled
       LoggingConfiguration:
         DestinationBucketName: !Ref rS3AccessLoggingBucket
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
       PublicAccessBlockConfiguration:
         BlockPublicAcls: TRUE
         BlockPublicPolicy: TRUE

--- a/logging/centralized-logging-config-s3-bucket/cfn-centralized-logging-config-s3-bucket.yaml
+++ b/logging/centralized-logging-config-s3-bucket/cfn-centralized-logging-config-s3-bucket.yaml
@@ -90,15 +90,16 @@ Conditions:
 Resources:
 
   rS3AccessLoggingBucket:
-    Metadata:
-      cfn-lint:
-          ignore_checks:
-            - W3045
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Type: AWS::S3::Bucket
     # false positive due to if statement
     # checkov:skip=CKV_AWS_19:Ensure the S3 bucket has server-side-encryption enabled
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W3045
     Properties:
       BucketName: !Sub ${pS3BucketName}-access-logs-${AWS::AccountId}
       AccessControl: LogDeliveryWrite
@@ -170,6 +171,11 @@ Resources:
     Type: AWS::S3::Bucket
     # false positive due to if statement
     # checkov:skip=CKV_AWS_19:Ensure the S3 bucket has server-side-encryption enabled
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W3045
     Properties:
       BucketName: !Sub ${pS3BucketName}-${AWS::AccountId}
       VersioningConfiguration:

--- a/logging/centralized-logging-config-s3-bucket/cfn-centralized-logging-config-s3-bucket.yaml
+++ b/logging/centralized-logging-config-s3-bucket/cfn-centralized-logging-config-s3-bucket.yaml
@@ -90,6 +90,10 @@ Conditions:
 Resources:
 
   rS3AccessLoggingBucket:
+    Metadata:
+      cfn-lint:
+          ignore_checks:
+            - W3045
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Type: AWS::S3::Bucket
@@ -157,6 +161,10 @@ Resources:
                 aws:SecureTransport: false
 
   rS3ConfigBucket:
+    Metadata:
+      cfn-lint:
+          ignore_checks:
+            - W3045
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Type: AWS::S3::Bucket

--- a/logging/centralized-logging-config-s3-bucket/cfn-centralized-logging-config-s3-bucket.yaml
+++ b/logging/centralized-logging-config-s3-bucket/cfn-centralized-logging-config-s3-bucket.yaml
@@ -162,10 +162,6 @@ Resources:
                 aws:SecureTransport: false
 
   rS3ConfigBucket:
-    Metadata:
-      cfn-lint:
-          ignore_checks:
-            - W3045
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Type: AWS::S3::Bucket


### PR DESCRIPTION
Fixes the CI issues with aws config and cloudtrail logging setup. Explicitly suppresses the warning given. Backlog work for putting the access logging into the bucket policy. 