### PR TITLE
chore: Add missing npm dependency @aws-sdk/client-sts in run-assessment.sh

### DIFF
--- a/cfat/run-assessment.sh
+++ b/cfat/run-assessment.sh
@@ -5,6 +5,7 @@ cd ./cfat
 echo "installing npm packages..."
 
 for i in \
+  '@aws-sdk/client-sts' \
   '@aws-sdk/client-cloudtrail' \
   '@aws-sdk/client-config-service' \
   '@aws-sdk/client-ec2' \


### PR DESCRIPTION
*Issue #, if available:*

When I run cfat/run-assessment.sh from CloudShell, I get this error:

installing npm packages...
installation complete, starting cloud foundation assessment...
node:internal/modules/cjs/loader:1228
  throw err;
  ^

Error: Cannot find module '@aws-sdk/client-sts'
Require stack:
- /home/cloudshell-user/cfat/[stdin]
    at Module._resolveFilename (node:internal/modules/cjs/loader:1225:15)
    at Module._load (node:internal/modules/cjs/loader:1051:27)
    at Module.require (node:internal/modules/cjs/loader:1311:19)
    at require (node:internal/modules/helpers:179:18)
    at [stdin]:1:28
    at [stdin]:1:55438
    at runScriptInThisContext (node:internal/vm:209:10)
    at node:internal/process/execution:118:14
    at [stdin]-wrapper:6:24
    at runScript (node:internal/process/execution:101:62) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/home/cloudshell-user/cfat/[stdin]' ]
}

Node.js v20.18.1


*Description of changes:*
Adding '@aws-sdk/client-sts' to the node dependencies to install fixes the error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
