### PR TITLE
fix: Added condition for regional permission set ARN format differences

### DIFF
--- a/control-tower/controltower-afc-hub/cfn-controltower-afc-hub.yaml
+++ b/control-tower/controltower-afc-hub/cfn-controltower-afc-hub.yaml
@@ -23,6 +23,9 @@ Parameters:
     Description: The IAM Identity Center managed IAM Role you use to access the AWS Control Tower dashboard
     Type: String
 
+Conditions:
+  cIsUsEast1: !Equals [!Ref 'AWS::Region', 'us-east-1']
+
 Resources:
   rAWSControlTowerBlueprintAccess:
     Type: AWS::IAM::Role
@@ -35,7 +38,10 @@ Resources:
             Principal:
               AWS:
                 - !Sub 'arn:aws:iam::${pManagementAccountId}:role/service-role/AWSControlTowerAdmin'
-                - !Sub 'arn:aws:iam::${pManagementAccountId}:role/aws-reserved/sso.amazonaws.com/${pAWSAdministratorAccessRole}'
+                - !If
+                  - cIsUsEast1
+                  - !Sub 'arn:aws:iam::${pManagementAccountId}:role/aws-reserved/sso.amazonaws.com/${pAWSAdministratorAccessRole}'
+                  - !Sub 'arn:aws:iam::${pManagementAccountId}:role/aws-reserved/sso.amazonaws.com/${AWS::Region}/${pAWSAdministratorAccessRole}'
             Action:
               - 'sts:AssumeRole'
       Path: /


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
Added condition to check if stack is being deployed in us-east-1. When home region for IAM Identity Center is us-east-1, the ARN format for permission set IAM roles is different than other regions. The ARN **does not** contain the region identifier if IAM Identity Center is hosted in us-east-1.

**us-east-1**: `arn:aws:iam::aws-account-ID:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_permission-set-name_unique-suffix`

**all other regions**: `arn:aws:iam::aws-account-ID:role/aws-reserved/sso.amazonaws.com/aws-region/AWSReservedSSO_permission-set-name_unique-suffix`

source: https://docs.aws.amazon.com/singlesignon/latest/userguide/referencingpermissionsets.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
